### PR TITLE
Allow DNSServerLookupMechanism to specify ports for the servers

### DIFF
--- a/minidns-android21/src/main/java/org/minidns/dnsserverlookup/android21/AndroidUsingLinkProperties.java
+++ b/minidns-android21/src/main/java/org/minidns/dnsserverlookup/android21/AndroidUsingLinkProperties.java
@@ -45,7 +45,7 @@ public class AndroidUsingLinkProperties extends AbstractDNSServerLookupMechanism
 
     @Override
     @TargetApi(21)
-    public List<IPPortPair> getDnsServerAddresses() {
+    public List<IPPortPair> getDnsServerAddressesWithPorts() {
         Network[] networks = connectivityManager.getAllNetworks();
         if (networks == null) {
             return null;

--- a/minidns-android21/src/main/java/org/minidns/dnsserverlookup/android21/AndroidUsingLinkProperties.java
+++ b/minidns-android21/src/main/java/org/minidns/dnsserverlookup/android21/AndroidUsingLinkProperties.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.minidns.dnsserverlookup.AbstractDNSServerLookupMechanism;
 import org.minidns.dnsserverlookup.AndroidUsingExec;
+import org.minidns.dnsserverlookup.IPPortPair;
 
 /**
  * Requires the ACCESS_NETWORK_STATE permission.
@@ -44,7 +45,7 @@ public class AndroidUsingLinkProperties extends AbstractDNSServerLookupMechanism
 
     @Override
     @TargetApi(21)
-    public List<String> getDnsServerAddresses() {
+    public List<IPPortPair> getDnsServerAddresses() {
         Network[] networks = connectivityManager.getAllNetworks();
         if (networks == null) {
             return null;
@@ -69,7 +70,7 @@ public class AndroidUsingLinkProperties extends AbstractDNSServerLookupMechanism
             return null;
         }
 
-        return servers;
+        return stringCollectionToListOfIPPortPairs(servers);
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)

--- a/minidns-client/src/main/java/org/minidns/DNSClient.java
+++ b/minidns-client/src/main/java/org/minidns/DNSClient.java
@@ -272,7 +272,7 @@ public class DNSClient extends AbstractDNSClient {
     public static List<IPPortPair> findDNS() {
         List<IPPortPair> res = null;
         for (DNSServerLookupMechanism mechanism : LOOKUP_MECHANISMS) {
-            res = mechanism.getDnsServerAddresses();
+            res = mechanism.getDnsServerAddressesWithPorts();
             if (res == null) {
                 continue;
             }

--- a/minidns-client/src/main/java/org/minidns/dnsserverlookup/AbstractDNSServerLookupMechanism.java
+++ b/minidns-client/src/main/java/org/minidns/dnsserverlookup/AbstractDNSServerLookupMechanism.java
@@ -44,7 +44,7 @@ public abstract class AbstractDNSServerLookupMechanism implements DNSServerLooku
     }
 
     @Override
-    public abstract List<IPPortPair> getDnsServerAddresses();
+    public abstract List<IPPortPair> getDnsServerAddressesWithPorts();
 
     protected static List<String> toListOfStrings(Collection<? extends InetAddress> inetAddresses) {
         List<String> result = new ArrayList<>(inetAddresses.size());

--- a/minidns-client/src/main/java/org/minidns/dnsserverlookup/AbstractDNSServerLookupMechanism.java
+++ b/minidns-client/src/main/java/org/minidns/dnsserverlookup/AbstractDNSServerLookupMechanism.java
@@ -44,13 +44,30 @@ public abstract class AbstractDNSServerLookupMechanism implements DNSServerLooku
     }
 
     @Override
-    public abstract List<String> getDnsServerAddresses();
+    public abstract List<IPPortPair> getDnsServerAddresses();
 
     protected static List<String> toListOfStrings(Collection<? extends InetAddress> inetAddresses) {
         List<String> result = new ArrayList<>(inetAddresses.size());
         for (InetAddress inetAddress : inetAddresses) {
             String address = inetAddress.getHostAddress();
             result.add(address);
+        }
+        return result;
+    }
+
+    protected static List<IPPortPair> inetAddressCollectionToListOfIPPortPairs(Collection<? extends InetAddress> inetAddresses){
+        List<IPPortPair> result = new ArrayList<>(inetAddresses.size());
+        for (InetAddress inetAddress : inetAddresses) {
+            String address = inetAddress.getHostAddress();
+            result.add(new IPPortPair(address, IPPortPair.DEFAULT_PORT));
+        }
+        return result;
+    }
+
+    protected static List<IPPortPair> stringCollectionToListOfIPPortPairs(Collection<String> serverAddresses){
+        List<IPPortPair> result = new ArrayList<>(serverAddresses.size());
+        for (String address : serverAddresses) {
+            result.add(new IPPortPair(address, IPPortPair.DEFAULT_PORT));
         }
         return result;
     }

--- a/minidns-client/src/main/java/org/minidns/dnsserverlookup/AndroidUsingExec.java
+++ b/minidns-client/src/main/java/org/minidns/dnsserverlookup/AndroidUsingExec.java
@@ -38,7 +38,7 @@ public class AndroidUsingExec extends AbstractDNSServerLookupMechanism {
     }
 
     @Override
-    public List<IPPortPair> getDnsServerAddresses() {
+    public List<IPPortPair> getDnsServerAddressesWithPorts() {
         try {
             Process process = Runtime.getRuntime().exec("getprop");
             InputStream inputStream = process.getInputStream();

--- a/minidns-client/src/main/java/org/minidns/dnsserverlookup/AndroidUsingExec.java
+++ b/minidns-client/src/main/java/org/minidns/dnsserverlookup/AndroidUsingExec.java
@@ -38,7 +38,7 @@ public class AndroidUsingExec extends AbstractDNSServerLookupMechanism {
     }
 
     @Override
-    public List<String> getDnsServerAddresses() {
+    public List<IPPortPair> getDnsServerAddresses() {
         try {
             Process process = Runtime.getRuntime().exec("getprop");
             InputStream inputStream = process.getInputStream();
@@ -48,7 +48,7 @@ public class AndroidUsingExec extends AbstractDNSServerLookupMechanism {
             if (server.size() > 0) {
                 List<String> res = new ArrayList<>(server.size());
                 res.addAll(server);
-                return res;
+                return stringCollectionToListOfIPPortPairs(res);
             }
         } catch (IOException e) {
             LOGGER.log(Level.WARNING, "Exception in findDNSByExec", e);

--- a/minidns-client/src/main/java/org/minidns/dnsserverlookup/AndroidUsingReflection.java
+++ b/minidns-client/src/main/java/org/minidns/dnsserverlookup/AndroidUsingReflection.java
@@ -31,7 +31,7 @@ public class AndroidUsingReflection extends AbstractDNSServerLookupMechanism {
     }
 
     @Override
-    public List<IPPortPair> getDnsServerAddresses() {
+    public List<IPPortPair> getDnsServerAddressesWithPorts() {
         try {
             Class<?> SystemProperties =
                     Class.forName("android.os.SystemProperties");

--- a/minidns-client/src/main/java/org/minidns/dnsserverlookup/AndroidUsingReflection.java
+++ b/minidns-client/src/main/java/org/minidns/dnsserverlookup/AndroidUsingReflection.java
@@ -31,7 +31,7 @@ public class AndroidUsingReflection extends AbstractDNSServerLookupMechanism {
     }
 
     @Override
-    public List<String> getDnsServerAddresses() {
+    public List<IPPortPair> getDnsServerAddresses() {
         try {
             Class<?> SystemProperties =
                     Class.forName("android.os.SystemProperties");
@@ -63,7 +63,7 @@ public class AndroidUsingReflection extends AbstractDNSServerLookupMechanism {
             }
 
             if (servers.size() > 0) {
-                return servers;
+                return stringCollectionToListOfIPPortPairs(servers);
             }
         } catch (Exception e) {
             // we might trigger some problems this way

--- a/minidns-client/src/main/java/org/minidns/dnsserverlookup/DNSServerLookupMechanism.java
+++ b/minidns-client/src/main/java/org/minidns/dnsserverlookup/DNSServerLookupMechanism.java
@@ -29,6 +29,6 @@ public interface DNSServerLookupMechanism extends Comparable<DNSServerLookupMech
      *
      * @return a List of Strings presenting hopefully IP addresses.
      */
-    public List<IPPortPair> getDnsServerAddresses();
+    public List<IPPortPair> getDnsServerAddressesWithPorts();
 
 }

--- a/minidns-client/src/main/java/org/minidns/dnsserverlookup/DNSServerLookupMechanism.java
+++ b/minidns-client/src/main/java/org/minidns/dnsserverlookup/DNSServerLookupMechanism.java
@@ -29,6 +29,6 @@ public interface DNSServerLookupMechanism extends Comparable<DNSServerLookupMech
      *
      * @return a List of Strings presenting hopefully IP addresses.
      */
-    public List<String> getDnsServerAddresses();
+    public List<IPPortPair> getDnsServerAddresses();
 
 }

--- a/minidns-client/src/main/java/org/minidns/dnsserverlookup/IPPortPair.java
+++ b/minidns-client/src/main/java/org/minidns/dnsserverlookup/IPPortPair.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015-2018 the original author or authors
+ *
+ * This software is licensed under the Apache License, Version 2.0,
+ * the GNU Lesser General Public License version 2 or later ("LGPL")
+ * and the WTFPL.
+ * You may choose either license to govern your use of this software only
+ * upon the condition that you accept all of the terms of either
+ * the Apache License 2.0, the LGPL 2.1+ or the WTFPL.
+ */
+package org.minidns.dnsserverlookup;
+
+import java.io.Serializable;
+
+/**
+ * Copyright Daniel Wolf 2018
+ * All rights reserved.
+ * Code may NOT be used without proper permission, neither in binary nor in source form.
+ * All redistributions of this software in source code must retain this copyright header
+ * All redistributions of this software in binary form must visibly inform users about usage of this software
+ * <p>
+ * development@frostnerd.com
+ */
+public class IPPortPair implements Serializable {
+    private static final long serialVersionUID = 7354713072355023750L;
+    public static final int DEFAULT_PORT = 53;
+    private int port;
+    private String ip;
+
+    public IPPortPair(String ip) {
+        this(ip, DEFAULT_PORT);
+    }
+
+    public IPPortPair(String ip, int port) {
+        this.port = port;
+        this.ip = ip;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public String getIp() {
+        return ip;
+    }
+}

--- a/minidns-client/src/main/java/org/minidns/dnsserverlookup/UnixUsingEtcResolvConf.java
+++ b/minidns-client/src/main/java/org/minidns/dnsserverlookup/UnixUsingEtcResolvConf.java
@@ -34,7 +34,7 @@ public class UnixUsingEtcResolvConf extends AbstractDNSServerLookupMechanism {
     private static final String RESOLV_CONF_FILE = "/etc/resolv.conf";
     private static final Pattern NAMESERVER_PATTERN = Pattern.compile("^nameserver\\s+(.*)$");
 
-    private static List<String> cached;
+    private static List<IPPortPair> cached;
     private static long lastModified;
 
     private UnixUsingEtcResolvConf() {
@@ -42,7 +42,7 @@ public class UnixUsingEtcResolvConf extends AbstractDNSServerLookupMechanism {
     }
 
     @Override
-    public List<String> getDnsServerAddresses() {
+    public List<IPPortPair> getDnsServerAddresses() {
         File file = new File(RESOLV_CONF_FILE);
         if (!file.exists()) {
             // Not very unixoid systems
@@ -81,7 +81,7 @@ public class UnixUsingEtcResolvConf extends AbstractDNSServerLookupMechanism {
             return null;
         }
 
-        cached = servers;
+        cached = stringCollectionToListOfIPPortPairs(servers);
         lastModified = currentLastModified;
 
         return cached;

--- a/minidns-client/src/main/java/org/minidns/dnsserverlookup/UnixUsingEtcResolvConf.java
+++ b/minidns-client/src/main/java/org/minidns/dnsserverlookup/UnixUsingEtcResolvConf.java
@@ -42,7 +42,7 @@ public class UnixUsingEtcResolvConf extends AbstractDNSServerLookupMechanism {
     }
 
     @Override
-    public List<IPPortPair> getDnsServerAddresses() {
+    public List<IPPortPair> getDnsServerAddressesWithPorts() {
         File file = new File(RESOLV_CONF_FILE);
         if (!file.exists()) {
             // Not very unixoid systems

--- a/minidns-client/src/test/java/org/minidns/DNSClientTest.java
+++ b/minidns-client/src/test/java/org/minidns/DNSClientTest.java
@@ -16,6 +16,7 @@ import org.minidns.dnsserverlookup.AbstractDNSServerLookupMechanism;
 import org.minidns.dnsserverlookup.AndroidUsingExec;
 import org.minidns.dnsserverlookup.AndroidUsingReflection;
 import org.minidns.dnsserverlookup.DNSServerLookupMechanism;
+import org.minidns.dnsserverlookup.IPPortPair;
 import org.minidns.record.A;
 import org.minidns.record.Record.TYPE;
 import org.minidns.source.DNSDataSource;
@@ -67,7 +68,7 @@ public class DNSClientTest {
             return true;
         }
         @Override
-        public List<String> getDnsServerAddresses() {
+        public List<IPPortPair> getDnsServerAddresses() {
             return null;
         }
     }

--- a/minidns-client/src/test/java/org/minidns/DNSClientTest.java
+++ b/minidns-client/src/test/java/org/minidns/DNSClientTest.java
@@ -68,7 +68,7 @@ public class DNSClientTest {
             return true;
         }
         @Override
-        public List<IPPortPair> getDnsServerAddresses() {
+        public List<IPPortPair> getDnsServerAddressesWithPorts() {
             return null;
         }
     }


### PR DESCRIPTION
As far as I can see there currently is no way to alter the port a query is sent to when using ResolverAPI or DnssecResolverApi. This would be possible if DNSServerLookupMechanism specified ports for the servers.

As this is a breaking change for projects using DNSServerLookupMechanism or AbstractDNSServerLookupMechanism it might be useful to keep the old getDnsServerAddresses() inside AbstractDNSServerLookupMechanism and mark it as deprecated, returning an empty list be default. A possible alteration could look like this:

`    /**
     * Port-aware replacement of {@link #getDnsServerAddresses()}
     *
     * @return A list of upstream DNS servers with their corresponding ports.
     *
     */
    @Override
    public List<IPPortPair> getDnsServerAddressesWithPorts(){
        List<String> servers = getDnsServerAddresses();
        // Throw some exception here if the list is empty?
        List<IPPortPair> pairs = new ArrayList<>(servers.size());
        for(String server: servers){
            pairs.add(new IPPortPair(server, IPPortPair.DEFAULT_PORT));
        }
        return pairs;
    }

    /**
     * @return A List containing non-null DNS servers represented as IP addresses
     *
     * @deprecated override {@link #getDnsServerAddressesWithPorts()} instead
     */
    public List<String> getDnsServerAddresses(){
        return Collections.emptyList();
    }
`
This however would break the concept of abstract classes as you would no longer be forced to implement getDnsServerAddressesWithPorts() in a subclass - that's why it isn't included in this commit.
