### PR TITLE
Only close sockets in NetworkDataSource when set to do so

### DIFF
--- a/minidns-client/src/main/java/org/minidns/source/NetworkDataSource.java
+++ b/minidns-client/src/main/java/org/minidns/source/NetworkDataSource.java
@@ -30,7 +30,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class NetworkDataSource extends DNSDataSource {
-
+    private boolean closeSocketAfterQuery = true;
     protected static final Logger LOGGER = Logger.getLogger(NetworkDataSource.class.getName());
 
     @Override
@@ -95,7 +95,7 @@ public class NetworkDataSource extends DNSDataSource {
             }
             return dnsMessage;
         } finally {
-            if (socket != null) {
+            if (socket != null && shouldCloseSocketAfterQuery()) {
                 socket.close();
             }
         }
@@ -126,10 +126,18 @@ public class NetworkDataSource extends DNSDataSource {
             }
             return dnsMessage;
         } finally {
-            if (socket != null) {
+            if (socket != null && shouldCloseSocketAfterQuery()) {
                 socket.close();
             }
         }
+    }
+
+    public void setCloseSocketAfterQuery(boolean closeSocketAfterQuery) {
+        this.closeSocketAfterQuery = closeSocketAfterQuery;
+    }
+
+    public boolean shouldCloseSocketAfterQuery() {
+        return closeSocketAfterQuery;
     }
 
     /**

--- a/minidns-client/src/test/java/org/minidns/source/NetworkDataSourceTest.java
+++ b/minidns-client/src/test/java/org/minidns/source/NetworkDataSourceTest.java
@@ -14,7 +14,9 @@ import org.junit.Test;
 import org.minidns.dnsmessage.DNSMessage;
 
 import java.io.IOException;
+import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.net.SocketException;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -46,5 +48,101 @@ public class NetworkDataSourceTest {
         TestNetworkDataSource world = new TestNetworkDataSource();
         assertNull(world.query(DNSMessage.builder().build(), null, 53));
         assertFalse(world.lastQueryUdp);
+    }
+
+    @Test
+    public void socketClosedByDefaultTest() throws SocketException {
+        final DatagramSocket dummySocket = new DatagramSocket() {
+            boolean closed = false;
+
+            @Override
+            public synchronized void close() {
+                closed = true;
+            }
+
+            @Override
+            public boolean isClosed() {
+                return closed;
+            }
+        };
+        class TestNetworkDataSource extends NetworkDataSource {
+            @Override
+            protected DatagramSocket createDatagramSocket() {
+                return dummySocket;
+            }
+        }
+        TestNetworkDataSource world = new TestNetworkDataSource();
+        // Everything has to be cached as this is going to throw a RuntimeException somewhere
+        try {
+            world.query(DNSMessage.builder().build(), null, 53);
+        } catch (Exception ignored) {}
+
+        assertTrue(dummySocket.isClosed());
+    }
+
+    @Test
+    public void socketNotClosedTest() throws SocketException {
+        final DatagramSocket dummySocket = new DatagramSocket() {
+            boolean closed = false;
+
+            @Override
+            public synchronized void close() {
+                closed = true;
+            }
+
+            @Override
+            public boolean isClosed() {
+                return closed;
+            }
+        };
+        class TestNetworkDataSource extends NetworkDataSource {
+            @Override
+            protected DatagramSocket createDatagramSocket() {
+                return dummySocket;
+            }
+
+            @Override
+            public boolean shouldCloseSocketAfterQuery() {
+                return false;
+            }
+        }
+        TestNetworkDataSource world = new TestNetworkDataSource();
+        // Everything has to be cached as this is going to throw a RuntimeException somewhere
+        try {
+            world.query(DNSMessage.builder().build(), null, 53);
+        } catch (Exception ignored) {}
+
+        assertFalse(dummySocket.isClosed());
+    }
+
+    @Test
+    public void socketNotClosedNoOverrideTest() throws SocketException {
+        final DatagramSocket dummySocket = new DatagramSocket() {
+            boolean closed = false;
+
+            @Override
+            public synchronized void close() {
+                closed = true;
+            }
+
+            @Override
+            public boolean isClosed() {
+                return closed;
+            }
+        };
+        class TestNetworkDataSource extends NetworkDataSource {
+            @Override
+            protected DatagramSocket createDatagramSocket() {
+                return dummySocket;
+            }
+        }
+        TestNetworkDataSource world = new TestNetworkDataSource();
+        world.setCloseSocketAfterQuery(false);
+        // Everything has to be cached as this is going to throw a RuntimeException somewhere
+        try {
+            world.query(DNSMessage.builder().build(), null, 53);
+        } catch (Exception ignored) {}
+
+        assertFalse(dummySocket.isClosed());
     }
 }


### PR DESCRIPTION
Currently DNS over TLS is a bit in the coming. As TLS connections are expensive (4-7 kB per connection if only one packet is sent + received; additionally the processing power required for the cryptography) they are held open for some time (which differs from host to host, around 3 seconds after no query was sent for cloudflare for example). Howevery, `NetworkDataSource` closes the socket after one query.

Previously it was only possible to prevent `NetworkDataSource` from closing the socket after the query has been processed by overriding it - which only increases the maintenance as the overridden code would be pretty much a duplicate of the existing code - or to implement a custom socket class which ignores calls to close() (which would be a stupid idea).

This PR introduces a flag to `NetworkDataSource` which sets whether the socket should be closed in the finally block.