### PR TITLE
README: Fix "records" typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ for (A a : answers) {
 }
 ```
 
-MiniDNS also provides full support for SRV resource reocrds and their handling.
+MiniDNS also provides full support for SRV resource records and their handling.
 
 ```java
 SrvResolverResult result = DnssecResolverApi.INSTANCE.resolveSrv(SrvType.xmpp_client, "example.org")


### PR DESCRIPTION
This is just a tiny fix for a typo in README doc.