### PR TITLE
WIP: Add SVCB record

### DIFF
--- a/minidns-core/src/main/java/org/minidns/constants/SVCBConstants.java
+++ b/minidns-core/src/main/java/org/minidns/constants/SVCBConstants.java
@@ -1,66 +1,23 @@
 package org.minidns.constants;
 
+import org.minidns.constants.svcbservicekeys.ALPNServiceKey;
+import org.minidns.constants.svcbservicekeys.ServiceKeySpecification;
+import org.minidns.constants.svcbservicekeys.UnrecognizedServiceKey;
+
+
 public class SVCBConstants {
-    public interface ServiceKeySpecification {
-        int getNumber();
-        String getTextualRepresentation();
-    }
-
-    public enum ServiceKey implements ServiceKeySpecification {
-        MANDATORY(0, "mandatory"),
-        ALPN(1, "alpn"),
-        NO_DEFAULT_ALPN(2, "no-default-alpn"),
-        PORT(3, "port"),
-        IPV4HINT(4, "ipv4hint"),
-        ECHOCONFIG(5, "echoconfig"),
-        IPV6HINT(6, "ipv6hint"),
-        INVALID_KEY(65535, "key65535");
-
-        private final int number;
-        private final String name;
-        ServiceKey(int number, String name) {
-            this.number = number;
-            this.name = name;
-        }
-
-        @Override
-        public int getNumber() {
-            return number;
-        }
-
-        @Override
-        public String getTextualRepresentation() {
-            return name;
-        }
-
-        public static ServiceKeySpecification findFrom(int number) {
-            for (ServiceKey value : values()) {
-                if(value.number == number) return value;
-            }
-            return new UnrecognizedServiceKey(number);
+    public static ServiceKeySpecification<?> findServiceKeyByNumber(int number, byte[] blob) {
+        switch (number) {
+            case 1: return new ALPNServiceKey(blob);
+            default: return new UnrecognizedServiceKey(blob, number);
         }
     }
 
-    public static final class UnrecognizedServiceKey implements ServiceKeySpecification {
-        private final int number;
-
-        public UnrecognizedServiceKey(int number) {
-            this.number = number;
-        }
-
-        @Override
-        public int getNumber() {
-            return number;
-        }
-
-        @Override
-        public String getTextualRepresentation() {
-            return String.valueOf(number);
-        }
-
-        @Override
-        public String toString() {
-            return "key" + number;
-        }
-    }
+    // ALPN(1, "alpn"),
+    // NO_DEFAULT_ALPN(2, "no-default-alpn"),
+    // PORT(3, "port"),
+    // IPV4HINT(4, "ipv4hint"),
+    // ECHOCONFIG(5, "echoconfig"),
+    // IPV6HINT(6, "ipv6hint"),
+    // INVALID_KEY(65535, "key65535");
 }

--- a/minidns-core/src/main/java/org/minidns/constants/SVCBConstants.java
+++ b/minidns-core/src/main/java/org/minidns/constants/SVCBConstants.java
@@ -1,0 +1,66 @@
+package org.minidns.constants;
+
+public class SVCBConstants {
+    public interface ServiceKeySpecification {
+        int getNumber();
+        String getTextualRepresentation();
+    }
+
+    public enum ServiceKey implements ServiceKeySpecification {
+        MANDATORY(0, "mandatory"),
+        ALPN(1, "alpn"),
+        NO_DEFAULT_ALPN(2, "no-default-alpn"),
+        PORT(3, "port"),
+        IPV4HINT(4, "ipv4hint"),
+        ECHOCONFIG(5, "echoconfig"),
+        IPV6HINT(6, "ipv6hint"),
+        INVALID_KEY(65535, "key65535");
+
+        private final int number;
+        private final String name;
+        ServiceKey(int number, String name) {
+            this.number = number;
+            this.name = name;
+        }
+
+        @Override
+        public int getNumber() {
+            return number;
+        }
+
+        @Override
+        public String getTextualRepresentation() {
+            return name;
+        }
+
+        public static ServiceKeySpecification findFrom(int number) {
+            for (ServiceKey value : values()) {
+                if(value.number == number) return value;
+            }
+            return new UnrecognizedServiceKey(number);
+        }
+    }
+
+    public static final class UnrecognizedServiceKey implements ServiceKeySpecification {
+        private final int number;
+
+        public UnrecognizedServiceKey(int number) {
+            this.number = number;
+        }
+
+        @Override
+        public int getNumber() {
+            return number;
+        }
+
+        @Override
+        public String getTextualRepresentation() {
+            return String.valueOf(number);
+        }
+
+        @Override
+        public String toString() {
+            return "key" + number;
+        }
+    }
+}

--- a/minidns-core/src/main/java/org/minidns/constants/svcbservicekeys/ALPNServiceKey.java
+++ b/minidns-core/src/main/java/org/minidns/constants/svcbservicekeys/ALPNServiceKey.java
@@ -1,0 +1,50 @@
+package org.minidns.constants.svcbservicekeys;
+
+import org.minidns.util.RRTextUtil;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ALPNServiceKey extends ServiceKeySpecification<List<String>> {
+    private List<String> value;
+
+    public ALPNServiceKey(byte[] blob) {
+        super(blob, 1);
+    }
+
+    @Override
+    public List<String> value() throws IOException {
+        if(value == null) {
+            List<String> values = new ArrayList<>();
+            DataInputStream dis = new DataInputStream(new ByteArrayInputStream(blob));
+            while(dis.available() > 0) {
+                byte[] blob = new byte[dis.readUnsignedShort()];
+                dis.readFully(blob);
+                values.add(RRTextUtil.getTextFrom(blob));
+            }
+            value = Collections.unmodifiableList(values);
+        }
+        return value;
+    }
+
+    @Override
+    public String getTextualRepresentation() {
+        return "alpn";
+    }
+
+    @Override
+    public String valueAsString() throws IOException {
+        StringBuilder sb = new StringBuilder();
+        for (String s : value()) {
+            if(sb.length() > 0) {
+                sb.append(",");
+            }
+            sb.append(s.replaceAll(",", "\\\\,"));
+        }
+        return sb.toString();
+    }
+}

--- a/minidns-core/src/main/java/org/minidns/constants/svcbservicekeys/ServiceKeySpecification.java
+++ b/minidns-core/src/main/java/org/minidns/constants/svcbservicekeys/ServiceKeySpecification.java
@@ -1,0 +1,31 @@
+package org.minidns.constants.svcbservicekeys;
+
+import java.io.IOException;
+
+public abstract class ServiceKeySpecification<ValueType> implements Comparable<ServiceKeySpecification<?>> {
+    public final byte[] blob;
+    public final int number;
+
+    public ServiceKeySpecification(byte[] blob, int number) {
+        this.blob = blob;
+        this.number = number;
+    }
+
+    public final int getNumber() {
+        return number;
+    }
+
+    abstract public ValueType value() throws IOException;
+    abstract public String getTextualRepresentation();
+    abstract public String valueAsString() throws IOException;
+
+    @Override
+    public int compareTo(ServiceKeySpecification<?> other) {
+        return getNumber() - other.getNumber();
+    }
+
+    @Override
+    public String toString() {
+        return getTextualRepresentation();
+    }
+}

--- a/minidns-core/src/main/java/org/minidns/constants/svcbservicekeys/UnrecognizedServiceKey.java
+++ b/minidns-core/src/main/java/org/minidns/constants/svcbservicekeys/UnrecognizedServiceKey.java
@@ -1,0 +1,24 @@
+package org.minidns.constants.svcbservicekeys;
+
+import java.util.Arrays;
+
+public class UnrecognizedServiceKey extends ServiceKeySpecification<byte[]>{
+    public UnrecognizedServiceKey(byte[] blob, int number) {
+        super(blob, number);
+    }
+
+    @Override
+    public byte[] value() {
+        return blob;
+    }
+
+    @Override
+    public String getTextualRepresentation() {
+        return "key" + number;
+    }
+
+    @Override
+    public String valueAsString() {
+        return Arrays.toString(blob);
+    }
+}

--- a/minidns-core/src/main/java/org/minidns/record/Record.java
+++ b/minidns-core/src/main/java/org/minidns/record/Record.java
@@ -99,7 +99,7 @@ public final class Record<D extends Data> {
         CDNSKEY(60),
         OPENPGPKEY(61, OPENPGPKEY.class),
         CSYNC(62),
-        SVCB(64, SVCB.class),
+        SVCB(65, SVCB.class),
         SPF(99),
         UINFO(100),
         UID(101),

--- a/minidns-core/src/main/java/org/minidns/record/Record.java
+++ b/minidns-core/src/main/java/org/minidns/record/Record.java
@@ -99,7 +99,7 @@ public final class Record<D extends Data> {
         CDNSKEY(60),
         OPENPGPKEY(61, OPENPGPKEY.class),
         CSYNC(62),
-        SVCB(64),
+        SVCB(64, SVCB.class),
         SPF(99),
         UINFO(100),
         UID(101),
@@ -399,6 +399,9 @@ public final class Record<D extends Data> {
                 break;
             case DLV:
                 payloadData = DLV.parse(dis, payloadLength);
+                break;
+            case SVCB:
+                payloadData = SVCB.parse(dis, payloadLength, data);
                 break;
             case UNKNOWN:
             default:

--- a/minidns-core/src/main/java/org/minidns/record/Record.java
+++ b/minidns-core/src/main/java/org/minidns/record/Record.java
@@ -99,6 +99,7 @@ public final class Record<D extends Data> {
         CDNSKEY(60),
         OPENPGPKEY(61, OPENPGPKEY.class),
         CSYNC(62),
+        SVCB(64),
         SPF(99),
         UINFO(100),
         UID(101),

--- a/minidns-core/src/main/java/org/minidns/record/SVCB.java
+++ b/minidns-core/src/main/java/org/minidns/record/SVCB.java
@@ -1,14 +1,16 @@
 package org.minidns.record;
 
+import org.minidns.constants.SVCBConstants;
 import org.minidns.dnsname.DnsName;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.TreeMap;
 
 /**
  * SVCB Record Type (Service binding)
@@ -26,60 +28,94 @@ class SVCB extends RRWithTarget {
     public final int priority;
 
     /**
-     * SvcFieldValue
-     * A set of key=value pairs.
+     * A set of key=value pairs (SvcFieldValue).
      * The key is an ID for the parameter.
+     *
+     * This is a sorted map to follow specification.
      *
      * @see <a href="https://tools.ietf.org/html/draft-ietf-dnsop-svcb-https-01#section-12.3.2">Possible parameter IDs</a>
      */
-    public final Map<String, String> values;
-
-    // The first group is the key. They key can only be a-z, 0-9 or "-"
-    // The second group is the value. It can be a lot of things (see https://tools.ietf.org/html/draft-ietf-dnsop-svcb-httpssvc-01#section-2.1.1)
-    // except for DQUOTE (hence it can be excluded from the regex-group)
-    private static final Pattern valuesPattern = Pattern.compile("([a-z0-9\\-]+)=\"([^\"]*)\"");
+    public final Map<SVCBConstants.ServiceKeySpecification, String> params;
 
     /**
-     * @param priority SvcRecordType
-     * @param target SvcDomainName
-     * @param values SvcFieldValue
+     * @param priority SvcPriority
+     * @param target TargetName
+     * @param params SvcParams
      */
-    public SVCB(int priority, DnsName target, Map<String, String> values) {
+    public SVCB(int priority, DnsName target, Map<SVCBConstants.ServiceKeySpecification, String> params) {
         super(target);
         this.priority = priority;
-        this.values = values;
+        TreeMap<SVCBConstants.ServiceKeySpecification, String> sorted = new TreeMap<>(new Comparator<SVCBConstants.ServiceKeySpecification>() {
+            @Override
+            public int compare(SVCBConstants.ServiceKeySpecification first, SVCBConstants.ServiceKeySpecification other) {
+                return first.getNumber() - other.getNumber(); //Ascending order
+            }
+        });
+        sorted.putAll(params);
+        this.params = Collections.unmodifiableSortedMap(sorted);
     }
 
+    /**
+     * Parses the wireformat data according to the spec.
+     *
+     * @see <a href="https://tools.ietf.org/html/draft-ietf-dnsop-svcb-https-01#section-2.2">RDATA wire format specification</a>
+     */
     public static SVCB parse(DataInputStream dis, int length, byte[] data)
             throws IOException {
         int priority = dis.readUnsignedShort();
         DnsName target = DnsName.parse(dis, data);
+        Map<SVCBConstants.ServiceKeySpecification, String> params;
 
-        byte[] valuesBlob = new byte[length - 2 - target.getRawBytes().length];
-        dis.readFully(valuesBlob);
-        return new SVCB(priority, target, parseValuesBlob(valuesBlob));
-    }
-
-    private static Map<String, String> parseValuesBlob(byte[] blob) {
-        Map<String, String> values = new LinkedHashMap<>();
-        String blobAsString = new String(blob, StandardCharsets.UTF_8);
-        Matcher matcher = valuesPattern.matcher(blobAsString);
-        while(matcher.find()) {
-            values.put(matcher.group(1), matcher.group(2));
+        int paramBlobSize = length - 2 - target.getRawBytes().length;
+        if(paramBlobSize == 0) {
+            params = Collections.emptyMap();
+        } else {
+            params = parseParamsBlob(dis, paramBlobSize);
         }
-        return values;
+
+        return new SVCB(priority, target, params);
     }
 
-    @Override
-    public Record.TYPE getType() {
-        return Record.TYPE.SVCB;
+    private static Map<SVCBConstants.ServiceKeySpecification, String> parseParamsBlob(DataInputStream dis, int paramBlobSize) throws IOException {
+        int remainingBytes = paramBlobSize;
+        int lastKey = Integer.MIN_VALUE;
+        Map<SVCBConstants.ServiceKeySpecification, String> params = new LinkedHashMap<>();
+
+        while(remainingBytes > 0) {
+            int key = dis.readUnsignedShort();
+            String value = null;
+            if(key < lastKey) throw new IllegalArgumentException("SVCB ServiceKeys must be in ascending order");
+            else if(key == lastKey) throw new IllegalArgumentException("SVCB ServiceKeys must not be duplicate");
+            lastKey = key;
+
+            int valueLength = dis.readUnsignedShort();
+            if(valueLength != 0) {
+                byte[] valueBlob = new byte[valueLength];
+                dis.readFully(valueBlob);
+                value = new String(valueBlob, StandardCharsets.UTF_8);
+            }
+
+            params.put(SVCBConstants.ServiceKey.findFrom(key), value);
+            remainingBytes = remainingBytes - 4 - valueLength;
+        }
+        return Collections.unmodifiableMap(params);
     }
 
     @Override
     public void serialize(DataOutputStream dos) throws IOException {
         dos.writeShort(priority);
         super.serialize(dos);
-        dos.write(createValuesString().getBytes(StandardCharsets.UTF_8));
+        for (Map.Entry<SVCBConstants.ServiceKeySpecification, String> entry : params.entrySet()) {
+            dos.writeShort(entry.getKey().getNumber());
+            byte[] paramValueBlob = entry.getValue().getBytes(StandardCharsets.UTF_8);
+            dos.writeShort(paramValueBlob.length);
+            dos.write(paramValueBlob);
+        }
+    }
+
+    @Override
+    public Record.TYPE getType() {
+        return Record.TYPE.SVCB;
     }
 
     @Override
@@ -89,9 +125,9 @@ class SVCB extends RRWithTarget {
 
     private String createValuesString() {
         StringBuilder builder = new StringBuilder();
-        for (Map.Entry<String, String> entry : values.entrySet()) {
+        for (Map.Entry<SVCBConstants.ServiceKeySpecification, String> entry : params.entrySet()) {
             builder.append(" ");
-            builder.append(entry.getKey());
+            builder.append(entry.getKey().getTextualRepresentation());
             builder.append("=");
             builder.append("\"");
             builder.append(entry.getValue());

--- a/minidns-core/src/main/java/org/minidns/record/SVCB.java
+++ b/minidns-core/src/main/java/org/minidns/record/SVCB.java
@@ -1,0 +1,102 @@
+package org.minidns.record;
+
+import org.minidns.dnsname.DnsName;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * SVCB Record Type (Service binding)
+ *
+ * https://tools.ietf.org/html/draft-ietf-dnsop-svcb-httpssvc-01
+ */
+class SVCB extends RRWithTarget {
+
+    /**
+     * The priority indicates the SvcRecordType.
+     * https://tools.ietf.org/html/draft-ietf-dnsop-svcb-httpssvc-01#section-2.4
+     */
+    public final int priority;
+
+    /**
+     * SvcFieldValue
+     * A set of key=value pairs.
+     * https://tools.ietf.org/html/draft-ietf-dnsop-svcb-httpssvc-01#section-2.1
+     */
+    public final Map<String, String> values;
+
+    // The first group is the key. They key can only be a-z, 0-9 or "-"
+    // The second group is the value. It can be a lot of things (see https://tools.ietf.org/html/draft-ietf-dnsop-svcb-httpssvc-01#section-2.1.1)
+    //    except for DQUOTE (hence it can be excluded from the regex-group)
+    private static final Pattern valuesPattern = Pattern.compile("([a-z0-9\\-]+)=\"([^\"]*)\"");
+
+    /**
+     * @param priority SvcRecordType
+     * @param target SvcDomainName
+     * @param values SvcFieldValue
+     */
+    public SVCB(int priority, DnsName target, Map<String, String> values) {
+        super(target);
+        this.priority = priority;
+        this.values = values;
+    }
+
+    public static SVCB parse(DataInputStream dis, int length, byte[] data)
+            throws IOException {
+        int priority = dis.readUnsignedShort();
+        DnsName target = DnsName.parse(dis, data);
+
+        byte[] valuesBlob = new byte[length - 2 - target.getRawBytes().length];
+        dis.readFully(valuesBlob);
+        return new SVCB(priority, target, parseValuesBlob(valuesBlob));
+    }
+
+    /**
+     * Parses pairs according to format from https://tools.ietf.org/html/draft-ietf-dnsop-svcb-httpssvc-01#section-2.1.1
+     */
+    private static Map<String, String> parseValuesBlob(byte[] blob) {
+        Map<String, String> values = new LinkedHashMap<>();
+        String blobAsString = new String(blob, StandardCharsets.UTF_8);
+        Matcher matcher = valuesPattern.matcher(blobAsString);
+        while(matcher.find()) {
+            values.put(matcher.group(1), matcher.group(2));
+        }
+        return values;
+    }
+
+    @Override
+    public Record.TYPE getType() {
+        return Record.TYPE.SVCB;
+    }
+
+    @Override
+    public void serialize(DataOutputStream dos) throws IOException {
+        dos.writeShort(priority);
+        super.serialize(dos);
+        dos.write(createValuesString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public String toString() {
+        return priority + " " + target + createValuesString();
+    }
+
+    private String createValuesString() {
+        StringBuilder builder = new StringBuilder();
+        for (Map.Entry<String, String> entry : values.entrySet()) {
+            builder.append(" ");
+            builder.append(entry.getKey());
+            builder.append("=");
+            builder.append("\"");
+            builder.append(entry.getValue());
+            builder.append("\"");
+        }
+        return builder.toString();
+    }
+}

--- a/minidns-core/src/main/java/org/minidns/record/SVCB.java
+++ b/minidns-core/src/main/java/org/minidns/record/SVCB.java
@@ -5,7 +5,6 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -14,26 +13,30 @@ import java.util.regex.Pattern;
 /**
  * SVCB Record Type (Service binding)
  *
- * https://tools.ietf.org/html/draft-ietf-dnsop-svcb-httpssvc-01
+ * @see <a href="https://tools.ietf.org/html/draft-ietf-dnsop-svcb-https-01">draft-ietf-dnsop-svcb-https-01: Service binding and parameter specification via the DNS (DNS SVCB and HTTPS RRs)</a>
  */
 class SVCB extends RRWithTarget {
 
     /**
-     * The priority indicates the SvcRecordType.
-     * https://tools.ietf.org/html/draft-ietf-dnsop-svcb-httpssvc-01#section-2.4
+     * The priority indicates the SvcPriority.
+     * A SvcPriority of 0 puts this RR in AliasMode (otherwise ServiceMode).
+     *
+     * @see <a href="https://tools.ietf.org/html/draft-ietf-dnsop-svcb-https-01#page-12>SvcPriority</a>
      */
     public final int priority;
 
     /**
      * SvcFieldValue
      * A set of key=value pairs.
-     * https://tools.ietf.org/html/draft-ietf-dnsop-svcb-httpssvc-01#section-2.1
+     * The key is an ID for the parameter.
+     *
+     * @see <a href="https://tools.ietf.org/html/draft-ietf-dnsop-svcb-https-01#section-12.3.2">Possible parameter IDs</a>
      */
     public final Map<String, String> values;
 
     // The first group is the key. They key can only be a-z, 0-9 or "-"
     // The second group is the value. It can be a lot of things (see https://tools.ietf.org/html/draft-ietf-dnsop-svcb-httpssvc-01#section-2.1.1)
-    //    except for DQUOTE (hence it can be excluded from the regex-group)
+    // except for DQUOTE (hence it can be excluded from the regex-group)
     private static final Pattern valuesPattern = Pattern.compile("([a-z0-9\\-]+)=\"([^\"]*)\"");
 
     /**
@@ -57,9 +60,6 @@ class SVCB extends RRWithTarget {
         return new SVCB(priority, target, parseValuesBlob(valuesBlob));
     }
 
-    /**
-     * Parses pairs according to format from https://tools.ietf.org/html/draft-ietf-dnsop-svcb-httpssvc-01#section-2.1.1
-     */
     private static Map<String, String> parseValuesBlob(byte[] blob) {
         Map<String, String> values = new LinkedHashMap<>();
         String blobAsString = new String(blob, StandardCharsets.UTF_8);

--- a/minidns-core/src/main/java/org/minidns/util/RRTextUtil.java
+++ b/minidns-core/src/main/java/org/minidns/util/RRTextUtil.java
@@ -1,0 +1,13 @@
+package org.minidns.util;
+
+public class RRTextUtil {
+
+    public static String getTextFrom(byte[] blob) {
+        StringBuilder sb = new StringBuilder();
+        return sb.toString();
+    }
+
+    public static byte[] textToByteArray(String s)  {
+        return new byte[0];
+    }
+}

--- a/minidns-core/src/test/java/org/minidns/record/RecordsTest.java
+++ b/minidns-core/src/test/java/org/minidns/record/RecordsTest.java
@@ -12,6 +12,7 @@ package org.minidns.record;
 
 import org.minidns.constants.DnssecConstants.DigestAlgorithm;
 import org.minidns.constants.DnssecConstants.SignatureAlgorithm;
+import org.minidns.constants.SVCBConstants;
 import org.minidns.dnsname.DnsName;
 import org.minidns.record.NSEC3.HashAlgorithm;
 import org.minidns.record.Record.TYPE;
@@ -54,15 +55,31 @@ public class RecordsTest {
 
     @Test
     public void testSVCBRecord() throws Exception {
-        Map<String, String> values = new LinkedHashMap<>();
-        values.put("just", "testing");
-        values.put("lookma", "nopläintêxt");
-        values.put("even", "numbers like 1 and very long text with spaces in it.");
+        Map<SVCBConstants.ServiceKeySpecification, String> values = new HashMap<>();
+        values.put(SVCBConstants.ServiceKey.IPV6HINT, "testing"); //Number = 6
+        values.put(SVCBConstants.ServiceKey.ALPN, "nopläintêxt"); // Number = 1
+        values.put(SVCBConstants.ServiceKey.PORT, "numbers like 1 and very, very long text with spaces in it."); // Number = 3
+        values.put(new SVCBConstants.UnrecognizedServiceKey(65281), "unknown"); // 65281 is in the private use block.
         SVCB svcb = new SVCB(1, DnsName.from("example.com"), values);
 
         assertEquals(TYPE.SVCB, svcb.getType());
 
-        String expectedString = "1 example.com just=\"testing\" lookma=\"nopläintêxt\" even=\"numbers like 1 and very long text with spaces in it.\"";
+        // The keys should be ordered ascending
+        String expectedString = "1 example.com alpn=\"nopläintêxt\" port=\"numbers like 1 and very, very long text with spaces in it.\" ipv6hint=\"testing\" 65281=\"unknown\"";
+        assertEquals(expectedString, svcb.toString());
+        byte[] svcbb = svcb.toByteArray();
+        svcb = SVCB.parse(new DataInputStream(new ByteArrayInputStream(svcbb)), svcb.length(), svcbb);
+        assertEquals(expectedString, svcb.toString());
+    }
+
+    @Test
+    public void testSVCBRecord_NoParams() throws Exception {
+        SVCB svcb = new SVCB(0, DnsName.from("example.com"), Collections.<SVCBConstants.ServiceKeySpecification, String>emptyMap());
+
+        assertEquals(TYPE.SVCB, svcb.getType());
+
+        // The keys should be ordered ascending
+        String expectedString = "1 example.com";
         assertEquals(expectedString, svcb.toString());
         byte[] svcbb = svcb.toByteArray();
         svcb = SVCB.parse(new DataInputStream(new ByteArrayInputStream(svcbb)), svcb.length(), svcbb);

--- a/minidns-core/src/test/java/org/minidns/record/RecordsTest.java
+++ b/minidns-core/src/test/java/org/minidns/record/RecordsTest.java
@@ -60,6 +60,8 @@ public class RecordsTest {
         values.put("even", "numbers like 1 and very long text with spaces in it.");
         SVCB svcb = new SVCB(1, DnsName.from("example.com"), values);
 
+        assertEquals(TYPE.SVCB, svcb.getType());
+
         String expectedString = "1 example.com just=\"testing\" lookma=\"nopläintêxt\" even=\"numbers like 1 and very long text with spaces in it.\"";
         assertEquals(expectedString, svcb.toString());
         byte[] svcbb = svcb.toByteArray();

--- a/minidns-core/src/test/java/org/minidns/record/RecordsTest.java
+++ b/minidns-core/src/test/java/org/minidns/record/RecordsTest.java
@@ -12,7 +12,8 @@ package org.minidns.record;
 
 import org.minidns.constants.DnssecConstants.DigestAlgorithm;
 import org.minidns.constants.DnssecConstants.SignatureAlgorithm;
-import org.minidns.constants.SVCBConstants;
+import org.minidns.constants.svcbservicekeys.ServiceKeySpecification;
+import org.minidns.constants.svcbservicekeys.UnrecognizedServiceKey;
 import org.minidns.dnsname.DnsName;
 import org.minidns.record.NSEC3.HashAlgorithm;
 import org.minidns.record.Record.TYPE;
@@ -23,10 +24,9 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 import static org.minidns.Assert.assertCsEquals;
 import static org.minidns.Assert.assertArrayContentEquals;
@@ -55,31 +55,16 @@ public class RecordsTest {
 
     @Test
     public void testSVCBRecord() throws Exception {
-        Map<SVCBConstants.ServiceKeySpecification, String> values = new HashMap<>();
-        values.put(SVCBConstants.ServiceKey.IPV6HINT, "testing"); //Number = 6
-        values.put(SVCBConstants.ServiceKey.ALPN, "nopläintêxt"); // Number = 1
-        values.put(SVCBConstants.ServiceKey.PORT, "numbers like 1 and very, very long text with spaces in it."); // Number = 3
-        values.put(new SVCBConstants.UnrecognizedServiceKey(65281), "unknown"); // 65281 is in the private use block.
-        SVCB svcb = new SVCB(1, DnsName.from("example.com"), values);
+        Set<ServiceKeySpecification<?>> params = new TreeSet<>();
+        params.add(new UnrecognizedServiceKey(new byte[1], 6));
+        params.add(new UnrecognizedServiceKey(new byte[1], 1));
+        params.add(new UnrecognizedServiceKey(new byte[1], 3));
+        SVCB svcb = new SVCB(1, DnsName.from("example.com"), params);
 
         assertEquals(TYPE.SVCB, svcb.getType());
 
         // The keys should be ordered ascending
         String expectedString = "1 example.com alpn=\"nopläintêxt\" port=\"numbers like 1 and very, very long text with spaces in it.\" ipv6hint=\"testing\" 65281=\"unknown\"";
-        assertEquals(expectedString, svcb.toString());
-        byte[] svcbb = svcb.toByteArray();
-        svcb = SVCB.parse(new DataInputStream(new ByteArrayInputStream(svcbb)), svcb.length(), svcbb);
-        assertEquals(expectedString, svcb.toString());
-    }
-
-    @Test
-    public void testSVCBRecord_NoParams() throws Exception {
-        SVCB svcb = new SVCB(0, DnsName.from("example.com"), Collections.<SVCBConstants.ServiceKeySpecification, String>emptyMap());
-
-        assertEquals(TYPE.SVCB, svcb.getType());
-
-        // The keys should be ordered ascending
-        String expectedString = "1 example.com";
         assertEquals(expectedString, svcb.toString());
         byte[] svcbb = svcb.toByteArray();
         svcb = SVCB.parse(new DataInputStream(new ByteArrayInputStream(svcbb)), svcb.length(), svcbb);

--- a/minidns-core/src/test/java/org/minidns/record/RecordsTest.java
+++ b/minidns-core/src/test/java/org/minidns/record/RecordsTest.java
@@ -12,6 +12,7 @@ package org.minidns.record;
 
 import org.minidns.constants.DnssecConstants.DigestAlgorithm;
 import org.minidns.constants.DnssecConstants.SignatureAlgorithm;
+import org.minidns.dnsname.DnsName;
 import org.minidns.record.NSEC3.HashAlgorithm;
 import org.minidns.record.Record.TYPE;
 import org.junit.jupiter.api.Test;
@@ -21,7 +22,10 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.minidns.Assert.assertCsEquals;
 import static org.minidns.Assert.assertArrayContentEquals;
@@ -46,6 +50,21 @@ public class RecordsTest {
         byte[] ab = a.toByteArray();
         a = A.parse(new DataInputStream(new ByteArrayInputStream(ab)));
         assertArrayEquals(new byte[] {127, 0, 0, 1}, a.getIp());
+    }
+
+    @Test
+    public void testSVCBRecord() throws Exception {
+        Map<String, String> values = new LinkedHashMap<>();
+        values.put("just", "testing");
+        values.put("lookma", "nopläintêxt");
+        values.put("even", "numbers like 1 and very long text with spaces in it.");
+        SVCB svcb = new SVCB(1, DnsName.from("example.com"), values);
+
+        String expectedString = "1 example.com just=\"testing\" lookma=\"nopläintêxt\" even=\"numbers like 1 and very long text with spaces in it.\"";
+        assertEquals(expectedString, svcb.toString());
+        byte[] svcbb = svcb.toByteArray();
+        svcb = SVCB.parse(new DataInputStream(new ByteArrayInputStream(svcbb)), svcb.length(), svcbb);
+        assertEquals(expectedString, svcb.toString());
     }
 
     @Test


### PR DESCRIPTION
SVCB is a new record type currently in draft: https://tools.ietf.org/html/draft-ietf-dnsop-svcb-https-01

Support for it has already been added to Safari in iOS 14 (where it is used by default instead of A/AAAA), Cloudflare also added support for it [just recently](https://blog.cloudflare.com/speeding-up-https-and-http-3-negotiation-with-dns/). Mozilla announced to implement it soon as well.

This PR adds the TYPE (RR type 64 according to the RFC) and the Data class for it.