### PR TITLE
core: Drop build date from version to make the project reproducible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,6 @@ allprojects {
 		androidBootClasspath = getAndroidRuntimeJar(minidnsMinAndroidSdk)
 		rootConfigDir = new File(rootDir, 'config')
 		gitCommit = getGitCommit()
-		builtDate = (new java.text.SimpleDateFormat("yyyy-MM-dd")).format(new Date())
 		isReleaseVersion = !isSnapshot
 		isContinuousIntegrationEnvironment = Boolean.parseBoolean(System.getenv('CI'))
 		signingRequired = !(isSnapshot || isContinuousIntegrationEnvironment)

--- a/minidns-core/build.gradle
+++ b/minidns-core/build.gradle
@@ -12,7 +12,7 @@ class CreateFileTask extends DefaultTask {
 }
 
 task createVersionResource(type: CreateFileTask) {
-	fileContent = version + ' (' + gitCommit + ' ' + builtDate + ')'
+	fileContent = version + ' (' + gitCommit + ')'
 	outputFile = new File(projectDir, 'src/main/resources/org.minidns/version')
 }
 


### PR DESCRIPTION
Closes: #111.

Reproducible builds are an important way to independently verify the integrity
of the binaries. See the argument for reproducible builds[1].

The jar file minidns-core-1.0.0.jar contains the file org.minidns/version which
in turn contains the date of the build. When built on different dates this leads
to different jar files.

Tests:

- Build succeeds with the build date dropped.
- The version in file org.minidns/version is '1.0.0 (non-git build)'.
- minidns can be built reproducibly[2].

Links:

1) https://reproducible-builds.org/
2) https://salsa.debian.org/debian/libminidns-java/-/jobs/1616137

Signed-off-by: Sunil Mohan Adapa <sunil@medhas.org>
Tested-by: Sunil Mohan Adapa <sunil@medhas.org>