### PR TITLE
Sanitize DNS labels (and names) in toString()

### DIFF
--- a/minidns-core/src/main/java/org/minidns/dnslabel/LdhLabel.java
+++ b/minidns-core/src/main/java/org/minidns/dnslabel/LdhLabel.java
@@ -61,17 +61,7 @@ public abstract class LdhLabel extends DnsLabel {
             return false;
         }
 
-        for (int i = 0; i < label.length(); i++) {
-            char c = label.charAt(i);
-            if ((c >= 'a' && c <= 'z')
-                    || (c >= 'A' && c <= 'Z')
-                    || (c >= '0' && c <= '9')
-                    || c == '-') {
-                continue;
-            }
-            return false;
-        }
-        return true;
+        return consistsOnlyOfLettersDigitsAndHypen(label);
     }
 
     protected static LdhLabel fromInternal(String label) {

--- a/minidns-core/src/test/java/org/minidns/dnslabel/DnsLabelTest.java
+++ b/minidns-core/src/test/java/org/minidns/dnslabel/DnsLabelTest.java
@@ -10,6 +10,7 @@
  */
 package org.minidns.dnslabel;
 
+import static org.minidns.Assert.assertCsEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -94,5 +95,10 @@ public class DnsLabelTest {
     @Test
     public void dnsLabelWildcardStringTest() {
         assertEquals("*", DnsLabel.WILDCARD_LABEL.toString());
+    }
+
+    @Test
+    public void escapeUnsafeCharactersTest() {
+        assertCsEquals("foo〚2E〛bar", DnsLabel.from("foo.bar"));
     }
 }

--- a/minidns-core/src/test/java/org/minidns/dnsname/DnsNameTest.java
+++ b/minidns-core/src/test/java/org/minidns/dnsname/DnsNameTest.java
@@ -50,6 +50,30 @@ public class DnsNameTest {
     }
 
     @Test
+    public void parseLabelWillNullByteTest() throws IOException {
+        byte[] test = new byte[] {6, 'v', 'i', 'c', 't', 'i', 'm', 4, 'o', 'r', 'g', 0, 7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'o', 'r', 'g', 0};
+
+        DnsName dnsName = parse(test);
+        assertCsEquals("victim.org␀.example.org", dnsName);
+
+        DnsLabel orgWithoutNullByte = dnsName.getLabel(0);
+        assertArrayEquals(new char[] { 'o', 'r', 'g'}, orgWithoutNullByte.getRawLabel().toCharArray());
+
+        DnsLabel orgWithNullByte = dnsName.getLabel(2);
+        assertArrayEquals(new char[] { 'o', 'r', 'g', '\0'}, orgWithNullByte.getRawLabel().toCharArray());
+        assertArrayEquals(new char[] { 'o', 'r', 'g', '␀'}, orgWithNullByte.toString().toCharArray());
+    }
+
+    private static DnsName parse(byte[] bytes) throws IOException {
+        return DnsName.parse(new DataInputStream(new ByteArrayInputStream(bytes)), bytes);
+    }
+
+    @Test
+    public void constructInvalid() throws IOException {
+        DnsName.from("foo\\0nullbar");
+    }
+
+    @Test
     public void equalsTest() {
         assertEquals(DnsName.from(""), DnsName.from("."));
     }


### PR DESCRIPTION
The c-ares library was recently affected by an issue where a string
potentially containing a null byte (and other non-printable
characters) was handed to the user (CVE-2021-3672) [1].

We should also at least prevent the user from dealing with Strings
containing a null byte (if they don't explicitly ask for
it). Therefore, the toString() methods of DnsName and DnsLabel now
return a "null-byte safe" String.

1: https://www.openwall.com/lists/oss-security/2021/08/10/1