### PR TITLE
Intorduce SafeCharSequence and have DnsLabel and DnsName subclass it

### DIFF
--- a/minidns-core/src/main/java/org/minidns/dnslabel/DnsLabel.java
+++ b/minidns-core/src/main/java/org/minidns/dnslabel/DnsLabel.java
@@ -14,6 +14,8 @@ import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
+import org.minidns.util.SafeCharSequence;
+
 /**
  * A DNS label is an individual component of a DNS name. Labels are usually shown separated by dots.
  * <p>
@@ -29,7 +31,7 @@ import java.util.Locale;
  * @author Florian Schmaus
  *
  */
-public abstract class DnsLabel implements CharSequence, Comparable<DnsLabel> {
+public abstract class DnsLabel extends SafeCharSequence implements Comparable<DnsLabel> {
 
     /**
      * The maximum length of a DNS label in octets.
@@ -75,21 +77,6 @@ public abstract class DnsLabel implements CharSequence, Comparable<DnsLabel> {
 
     public final String getLabelType() {
         return getClass().getSimpleName();
-    }
-
-    @Override
-    public final int length() {
-        return label.length();
-    }
-
-    @Override
-    public final char charAt(int index) {
-        return label.charAt(index);
-    }
-
-    @Override
-    public final CharSequence subSequence(int start, int end) {
-        return label.subSequence(start, end);
     }
 
     private transient String safeToStringRepresentation;

--- a/minidns-core/src/main/java/org/minidns/dnsname/DnsName.java
+++ b/minidns-core/src/main/java/org/minidns/dnsname/DnsName.java
@@ -22,6 +22,7 @@ import java.util.Locale;
 
 import org.minidns.dnslabel.DnsLabel;
 import org.minidns.idna.MiniDnsIdna;
+import org.minidns.util.SafeCharSequence;
 
 /**
  * A DNS name, also called "domain name". A DNS name consists of multiple 'labels' (see {@link DnsLabel}) and is subject to certain restrictions (see
@@ -47,7 +48,7 @@ import org.minidns.idna.MiniDnsIdna;
  * @author Florian Schmaus
  *
  */
-public final class DnsName implements CharSequence, Serializable, Comparable<DnsName> {
+public final class DnsName extends SafeCharSequence implements Serializable, Comparable<DnsName> {
 
     /**
      * 
@@ -341,21 +342,6 @@ public final class DnsName implements CharSequence, Serializable, Comparable<Dns
             }
         }
         return size;
-    }
-
-    @Override
-    public int length() {
-        return ace.length();
-    }
-
-    @Override
-    public char charAt(int index) {
-        return ace.charAt(index);
-    }
-
-    @Override
-    public CharSequence subSequence(int start, int end) {
-        return ace.subSequence(start, end);
     }
 
     private transient String safeToStringRepresentation;

--- a/minidns-core/src/main/java/org/minidns/util/SafeCharSequence.java
+++ b/minidns-core/src/main/java/org/minidns/util/SafeCharSequence.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015-2021 the original author or authors
+ *
+ * This software is licensed under the Apache License, Version 2.0,
+ * the GNU Lesser General Public License version 2 or later ("LGPL")
+ * and the WTFPL.
+ * You may choose either license to govern your use of this software only
+ * upon the condition that you accept all of the terms of either
+ * the Apache License 2.0, the LGPL 2.1+ or the WTFPL.
+ */
+package org.minidns.util;
+
+public class SafeCharSequence implements CharSequence {
+
+    @Override
+    public final int length() {
+        return toSafeString().length();
+    }
+
+    @Override
+    public final char charAt(int index) {
+        return toSafeString().charAt(index);
+    }
+
+    @Override
+    public final CharSequence subSequence(int start, int end) {
+        return toSafeString().subSequence(end, end);
+    }
+
+    public String toSafeString() {
+        // The default implementation assumes that toString() returns a safe
+        // representation. Subclasses may override toSafeString() if this assumption is
+        // not correct.
+        return toString();
+    }
+}


### PR DESCRIPTION
This changes the CharSequence representation of DnsLabel and DnsName
from the insecure raw representation (which may contain arbitrary
bytes) to the escaped safe representation.

See cfaf45a84103 ("Sanitize DNS labels (and names) in toString()") for
the motivation.