### PR TITLE
Add explicit cast to byte due to lossy-conversions warning.

### DIFF
--- a/minidns-core/src/main/java/org/minidns/record/NSEC.java
+++ b/minidns-core/src/main/java/org/minidns/record/NSEC.java
@@ -110,7 +110,7 @@ public class NSEC extends Data {
                 }
                 int a = (type >> 3) % 32;
                 int b = type % 8;
-                bitmap[a] |= 128 >> b;
+                bitmap[a] |= (byte)(128 >> b);
             }
             if (windowBlock != -1) writeOutBlock(bitmap, dos);
         } catch (IOException e) {


### PR DESCRIPTION
When building with Java 21, the following warning appears in the build log:
```
:minidns-dane-java7:debianMavenPom (Thread[#94,Task worker for ':' Thread 18,5,main]) completed. Took 0.031 secs.
/<<PKGBUILDDIR>>/minidns-core/src/main/java/org/minidns/record/NSEC.java:113: warning: [lossy-conversions] implicit cast from int to byte in compound assignment is possibly lossy
                bitmap[a] |= 128 >> b;
                                 ^
error: warnings found and -Werror specified
1 error
1 warning
:minidns-core:compileJava FAILED
```

Add explicit cast to byte to avoid this warning.