### PR TITLE
Workaround this-escape warning for Java 21

### DIFF
--- a/minidns-core/src/main/java/org/minidns/edns/EdnsOption.java
+++ b/minidns-core/src/main/java/org/minidns/edns/EdnsOption.java
@@ -28,6 +28,7 @@ public abstract class EdnsOption {
         this.optionData = optionData;
     }
 
+    @SuppressWarnings("this-escape")
     protected EdnsOption(byte[] optionData) {
         this.optionCode = getOptionCode().asInt;
         this.optionLength = optionData.length;

--- a/minidns-dnssec/src/main/java/org/minidns/dnssec/DnssecClient.java
+++ b/minidns-dnssec/src/main/java/org/minidns/dnssec/DnssecClient.java
@@ -504,7 +504,7 @@ public class DnssecClient extends ReliableDnsClient {
      *             the DNSKEY record for the domain and using the key with first flags bit set
      *             (also called key signing key)
      */
-    public void addSecureEntryPoint(DnsName name, byte[] key) {
+    public final void addSecureEntryPoint(DnsName name, byte[] key) {
         knownSeps.put(name, key);
     }
 


### PR DESCRIPTION
Java 21 generates 'this-escape' warning if an overridable method is called from the constructor. 

'EdnsOption' calls an abstract method from the constructor, producing a genuine warning. Changing this requires redesign, so the warning is only suppressed.

'DnssecClient' calls a public method that can be made final.