### PR TITLE
[client] use 1232 byte udp payload size buffer by default

### DIFF
--- a/minidns-client/src/main/java/org/minidns/source/AbstractDnsDataSource.java
+++ b/minidns-client/src/main/java/org/minidns/source/AbstractDnsDataSource.java
@@ -38,7 +38,7 @@ public abstract class AbstractDnsDataSource implements DnsDataSource {
         return future;
     }
 
-    protected int udpPayloadSize = 1024;
+    protected int udpPayloadSize = 1232;
 
     /**
      * DNS timeout.


### PR DESCRIPTION
DNS flag day of 2020 addressed optimum DNS message sizes to avoid IP fragmentation and minimize the usage of TCP. The recommendation for DNS software vendors was to "use a default EDNS buffer size" of 1232 bytes.

Fixes #142.
    
Reference: https://www.dnsflagday.net/2020/#action-dns-software-vendors
Reference: https://blog.cloudflare.com/dns-flag-day-2020/