### PR TITLE
[build] Only specify accessibility, html, reference, and syntax for X…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,7 +148,7 @@ allprojects {
 			// work, we extra add '-quiet', which is added anyway by
 			// gradle.
 			// See https://github.com/gradle/gradle/issues/2354
-			options.addStringOption('Xdoclint:all', '-quiet')
+			options.addStringOption('Xdoclint:accessibility,html,reference,syntax', '-quiet')
 			// Abort on javadoc warnings.
 			// See JDK-8200363 (https://bugs.openjdk.java.net/browse/JDK-8200363)
 			// for information about the -Xwerror option.


### PR DESCRIPTION
…doclint

This drops the 'missing' doclint check.